### PR TITLE
[WIP] Feature/sign bytes

### DIFF
--- a/src/main/java/ch/admin/bag/covidcertificate/signature/api/CMSSigningRequestDto.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/signature/api/CMSSigningRequestDto.java
@@ -1,0 +1,12 @@
+package ch.admin.bag.covidcertificate.signature.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class CMSSigningRequestDto {
+    private String data;
+}

--- a/src/main/java/ch/admin/bag/covidcertificate/signature/service/cms/CMSSigner.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/signature/service/cms/CMSSigner.java
@@ -6,4 +6,6 @@ import java.security.cert.CertificateEncodingException;
 
 abstract class CMSSigner {
 	public abstract String sign(String payloadCertificateAlias) throws CertificateEncodingException, IOException;
+	
+	public abstract String sign(byte[] payloadBytes) throws CertificateEncodingException, IOException;
 }

--- a/src/main/java/ch/admin/bag/covidcertificate/signature/service/cms/CMSSigningService.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/signature/service/cms/CMSSigningService.java
@@ -29,4 +29,16 @@ public class CMSSigningService {
 
 	}
 
+	public CMSSigningResponseDto sign(byte[] data) {
+		String signature;
+		try {
+			signature = cmsSigner.sign(data);
+		} catch (CertificateEncodingException | IOException e) {
+			throw new SignatureCreationException("Failed to sing certificate with data ", e);
+		}
+
+		return new CMSSigningResponseDto(signature);
+
+	}
+
 }

--- a/src/main/java/ch/admin/bag/covidcertificate/signature/service/cms/LocalCMSSignatureBuilder.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/signature/service/cms/LocalCMSSignatureBuilder.java
@@ -14,7 +14,7 @@ import java.security.PrivateKey;
 import java.util.Base64;
 
 public class LocalCMSSignatureBuilder {
-    private X509CertificateHolder payloadCertificate;
+    private byte[] payloadCertificate;
     private X509CertificateHolder signingCertificate;
     private PrivateKey signingCertificatePrivateKey;
 
@@ -35,9 +35,22 @@ public class LocalCMSSignatureBuilder {
      * Set payload certificate.
      * @param certificate payload certificate
      * @return this
+     * @throws IOException
      */
-    public LocalCMSSignatureBuilder withPayloadCertificate(X509CertificateHolder certificate) {
-        this.payloadCertificate = certificate;
+    public LocalCMSSignatureBuilder withPayloadCertificate(X509CertificateHolder certificate) throws IOException {
+        this.payloadCertificate = certificate.getEncoded();
+        return this;
+    }
+
+    /**
+     * Set payload bytes directly.
+     * 
+     * @param data payload bytes
+     * @return this
+     * @throws IOException
+     */
+    public LocalCMSSignatureBuilder withPayloadBytes(byte[] data) throws IOException {
+        this.payloadCertificate = data;
         return this;
     }
 
@@ -61,7 +74,7 @@ public class LocalCMSSignatureBuilder {
                 signedDataGenerator.addSignerInfoGenerator(signerInfoGenerator);
                 signedDataGenerator.addCertificate(this.signingCertificate);
                 CMSSignedData signedData = signedDataGenerator
-                        .generate(new CMSProcessableByteArray(this.payloadCertificate.getEncoded()), !detached);
+                        .generate(new CMSProcessableByteArray(this.payloadCertificate), !detached);
                 byte[] messageBytes = signedData.getEncoded();
                 return messageBytes;
             } catch (CMSException | IOException | OperatorCreationException var9) {

--- a/src/main/java/ch/admin/bag/covidcertificate/signature/service/cms/LocalCMSSigner.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/signature/service/cms/LocalCMSSigner.java
@@ -49,4 +49,13 @@ public class LocalCMSSigner extends CMSSigner {
 
 		return signedMessaged;
 	}
+
+	public String sign(byte[] data) throws CertificateEncodingException, IOException {
+		String signedMessaged = new LocalCMSSignatureBuilder()
+				.withSigningCertificate(new X509CertificateHolder(signingCertificate.getEncoded()), privateKey)
+				.withPayloadBytes(data).buildAsString();
+		log.info("Success");
+
+		return signedMessaged;
+	}
 }

--- a/src/main/java/ch/admin/bag/covidcertificate/signature/service/cms/LunaCMSSignatureBuilder.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/signature/service/cms/LunaCMSSignatureBuilder.java
@@ -16,7 +16,7 @@ import java.util.Base64;
 
 public class LunaCMSSignatureBuilder {
 
-    private X509CertificateHolder payloadCertificate;
+    private byte[] payloadCertificate;
     private X509CertificateHolder signingCertificate;
     private PrivateKey signingCertificatePrivateKey;
 
@@ -43,9 +43,22 @@ public class LunaCMSSignatureBuilder {
      * Set payload certificate.
      * @param certificate payload certificate
      * @return this
+     * @throws IOException
      */
-    public LunaCMSSignatureBuilder withPayloadCertificate(X509CertificateHolder certificate) {
-        this.payloadCertificate = certificate;
+    public LunaCMSSignatureBuilder withPayloadCertificate(X509CertificateHolder certificate) throws IOException {
+        this.payloadCertificate = certificate.getEncoded();
+        return this;
+    }
+
+    /**
+     * Set payload certificate.
+     * 
+     * @param data payload bytes
+     * @return this
+     * @throws IOException
+     */
+    public LunaCMSSignatureBuilder withPayloadBytes(byte[] data) throws IOException {
+        this.payloadCertificate = data;
         return this;
     }
 
@@ -73,7 +86,7 @@ public class LunaCMSSignatureBuilder {
                 signedDataGenerator.addSignerInfoGenerator(signerInfoGenerator);
                 signedDataGenerator.addCertificate(this.signingCertificate);
                 CMSSignedData signedData = signedDataGenerator
-                        .generate(new CMSProcessableByteArray(this.payloadCertificate.getEncoded()), !detached);
+                        .generate(new CMSProcessableByteArray(this.payloadCertificate), !detached);
                 byte[] messageBytes = signedData.getEncoded();
                 return messageBytes;
             } catch (CMSException | IOException | OperatorCreationException var9) {

--- a/src/main/java/ch/admin/bag/covidcertificate/signature/service/cms/LunaCMSSigner.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/signature/service/cms/LunaCMSSigner.java
@@ -50,4 +50,16 @@ public class LunaCMSSigner extends CMSSigner{
 
 		return signedMessaged;
 	}
+	
+	public String sign(byte[] data) throws CertificateEncodingException, IOException {
+		
+
+		String signedMessaged = new LunaCMSSignatureBuilder(LunaProvider.getInstance().getName())
+				.withSigningCertificate(new X509CertificateHolder(signingCertificate.getEncoded()), privateKey)
+				.withPayloadBytes(data).buildAsString();
+
+		log.info("Success");
+
+		return signedMessaged;
+	}
 }

--- a/src/main/java/ch/admin/bag/covidcertificate/signature/web/controller/CMSController.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/signature/web/controller/CMSController.java
@@ -1,5 +1,6 @@
 package ch.admin.bag.covidcertificate.signature.web.controller;
 
+import ch.admin.bag.covidcertificate.signature.api.CMSSigningRequestDto;
 import ch.admin.bag.covidcertificate.signature.api.CMSSigningResponseDto;
 import ch.admin.bag.covidcertificate.signature.service.cms.CMSSigningService;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -32,9 +33,9 @@ final class CMSController {
     }
 
     @PostMapping(value = "/{alias}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public CMSSigningResponseDto signBytes(@PathVariable String alias, @RequestBody String data) {
+    public CMSSigningResponseDto signBytes(@PathVariable String alias, @RequestBody CMSSigningRequestDto data) {
         var aliasDecoded = UriUtils.decode(alias, "UTF-8");
-        var dataDecoded = Base64.getDecoder().decode(data);
+        var dataDecoded = Base64.getDecoder().decode(data.getData());
         log.info("Signing certificate with alias {}", aliasDecoded);
         return cmsSigningService.sign(dataDecoded);
     }

--- a/src/main/java/ch/admin/bag/covidcertificate/signature/web/controller/CMSController.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/signature/web/controller/CMSController.java
@@ -2,11 +2,16 @@ package ch.admin.bag.covidcertificate.signature.web.controller;
 
 import ch.admin.bag.covidcertificate.signature.api.CMSSigningResponseDto;
 import ch.admin.bag.covidcertificate.signature.service.cms.CMSSigningService;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.Base64;
+
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriUtils;
@@ -24,6 +29,14 @@ final class CMSController {
         var aliasDecoded = UriUtils.decode(alias, "UTF-8");
         log.info("Signing certificate with alias {}", aliasDecoded);
         return cmsSigningService.sign(aliasDecoded);
+    }
+
+    @PostMapping(value = "/{alias}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public CMSSigningResponseDto signBytes(@PathVariable String alias, @RequestBody String data) {
+        var aliasDecoded = UriUtils.decode(alias, "UTF-8");
+        var dataDecoded = Base64.getDecoder().decode(data);
+        log.info("Signing certificate with alias {}", aliasDecoded);
+        return cmsSigningService.sign(dataDecoded);
     }
 }
 

--- a/src/main/java/ch/admin/bag/covidcertificate/signature/web/controller/CMSController.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/signature/web/controller/CMSController.java
@@ -32,11 +32,9 @@ final class CMSController {
         return cmsSigningService.sign(aliasDecoded);
     }
 
-    @PostMapping(value = "/{alias}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public CMSSigningResponseDto signBytes(@PathVariable String alias, @RequestBody CMSSigningRequestDto data) {
-        var aliasDecoded = UriUtils.decode(alias, "UTF-8");
+    @PostMapping(value = "/", produces = MediaType.APPLICATION_JSON_VALUE)
+    public CMSSigningResponseDto signBytes(@RequestBody CMSSigningRequestDto data) {
         var dataDecoded = Base64.getDecoder().decode(data.getData());
-        log.info("Signing certificate with alias {}", aliasDecoded);
         return cmsSigningService.sign(dataDecoded);
     }
 }

--- a/src/test/java/ch/admin/bag/covidcertificate/signature/web/controller/CMSControllerTest.java
+++ b/src/test/java/ch/admin/bag/covidcertificate/signature/web/controller/CMSControllerTest.java
@@ -10,7 +10,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -24,7 +24,7 @@ class CMSControllerTest {
     private final JFixture fixture = new JFixture();
 
     @Test
-    void shouldCallServiveToSignCertificateWithCorrectAlias(){
+    void shouldCallServiceToSignCertificateWithCorrectAlias(){
         var alias = fixture.create(String.class);
         cmsController.sign(alias);
         verify(cmsSigningService).sign(alias);
@@ -33,7 +33,7 @@ class CMSControllerTest {
     @Test
     void shouldReturnSignedCertificate(){
         var responseDto = fixture.create(CMSSigningResponseDto.class);
-        when(cmsSigningService.sign(any())).thenReturn(responseDto);
+        when(cmsSigningService.sign(anyString())).thenReturn(responseDto);
         var actual = cmsController.sign(fixture.create(String.class));
         assertEquals(responseDto, actual);
     }


### PR DESCRIPTION
In order to be able to upload any data to the gateway, we add a generic signer endpoint. Since the endpoint is protected with mutual TLS this should not increase the risk drastically, as only services with access to the client's private key can issue a signature of data.